### PR TITLE
Fix memory leak on multiple showing in a ReplaceRegion.

### DIFF
--- a/region/ReplaceRegion.js
+++ b/region/ReplaceRegion.js
@@ -26,6 +26,8 @@
                 return;
             }
 
+            this.stopListening(view);
+
             if (this.$placeholder) {
                 view.$el.replaceWith(this.$placeholder);
                 delete this.$placeholder;


### PR DESCRIPTION
The view remains in the _listeningTo property after destroying. Thus
invoking the #show() method with subsequent views causes links to all of them
to be retained.